### PR TITLE
Using a better github location

### DIFF
--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -1,8 +1,9 @@
 // Executed in context of buildscript
 repositories {
+    // Repo in addition to maven central
     maven {
         name 'build-repo'
-        url 'https://github.com/Netflix-Skunkworks/build-repo/raw/master/releases/'
+        url 'https://raw.github.com/Netflix-Skunkworks/build-repo/master/releases/' // gradle-release/gradle-release/1.0-SNAPSHOT/gradle-release-1.0-SNAPSHOT.jar
     }
 }
 dependencies {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the GitHub URL in the `gradle/buildscript.gradle` file for the `build-repo` Maven repository.

### Why are these changes being made?

The previous URL used 'github.com', which was less efficient; 'raw.github.com' provides a more direct path to the repository resources, ensuring faster access and reliability when fetching dependencies. This is critical for maintaining an efficient CI/CD pipeline.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->